### PR TITLE
FormatTranslators

### DIFF
--- a/CodeElements/FormatTranslators/src/FormatTranslators.py
+++ b/CodeElements/FormatTranslators/src/FormatTranslators.py
@@ -530,7 +530,7 @@ class BookShelf2ProBufFormat:
                     for sink in sink_list:
                         inst_name = sink[0]
                         if (self.insts[inst_name].GetType() == "MACRO"):
-                            pin_name = "Pinput_" + str(len(self.insts[inst_name].GetInputPins()))
+                            pin_name = inst_name + "/Pinput_" + str(len(self.insts[inst_name].GetInputPins()))
                             self.insts[inst_name].AddInputPin(MacroPin(pin_name, inst_name, sink[1], sink[2], "MACRO"))
                             sink_name_list.append(pin_name)
                         else:
@@ -539,7 +539,7 @@ class BookShelf2ProBufFormat:
                     driver_name = driver[0]
                     if (self.insts[driver_name].GetType() == "MACRO"):
                         pin_id = len(self.insts[driver_name].GetOutputPins())
-                        pin_name = "Poutput_" + str(pin_id)
+                        pin_name = inst_name + "/Poutput_" + str(pin_id)
                         macro_pin = MacroPin(pin_name, driver_name, driver[1], driver[2], "MACRO")
                         macro_pin.AddSinks(sink_name_list)
                         self.insts[driver_name].AddOutputPin(macro_pin)

--- a/CodeElements/FormatTranslators/src/FormatTranslators.py
+++ b/CodeElements/FormatTranslators/src/FormatTranslators.py
@@ -531,7 +531,7 @@ class BookShelf2ProBufFormat:
                         inst_name = sink[0]
                         if (self.insts[inst_name].GetType() == "MACRO"):
                             pin_name = "Pinput_" + str(len(self.insts[inst_name].GetInputPins()))
-                            self.insts[inst_name].AddInputPin(MacroPin(pin_name, inst_name, sink[1], sink[2]))
+                            self.insts[inst_name].AddInputPin(MacroPin(pin_name, inst_name, sink[1], sink[2], "MACRO"))
                             sink_name_list.append(pin_name)
                         else:
                             sink_name_list.append(inst_name)
@@ -540,7 +540,7 @@ class BookShelf2ProBufFormat:
                     if (self.insts[driver_name].GetType() == "MACRO"):
                         pin_id = len(self.insts[driver_name].GetOutputPins())
                         pin_name = "Poutput_" + str(pin_id)
-                        macro_pin = MacroPin(pin_name, driver_name, driver[1], driver[2])
+                        macro_pin = MacroPin(pin_name, driver_name, driver[1], driver[2], "MACRO")
                         macro_pin.AddSinks(sink_name_list)
                         self.insts[driver_name].AddOutputPin(macro_pin)
                     else:

--- a/CodeElements/FormatTranslators/test/Bookshelf2ProtocolBufferFormat/test1.py
+++ b/CodeElements/FormatTranslators/test/Bookshelf2ProtocolBufferFormat/test1.py
@@ -7,7 +7,9 @@ if __name__ == '__main__':
     # set up inputs
     benchmark_dir = './DAC2012_testcases'
     design = 'superblue19'
-
+    if(len(sys.argv)==3):
+    	benchmark_dir = sys.argv[1]
+    	design = sys.argv[2]
     # other parameters
     file_dir = benchmark_dir + '/' + design
     output_file = design + ".plc"


### PR DESCRIPTION
1. Fix TypeError
When I test BookShelf2ProBuf, it raised: 
`FormatTranslators.py", line 543, in ReadNetsFile
    macro_pin = MacroPin(pin_name, driver_name, driver[1], driver[2])
TypeError: __init__() missing 1 required positional argument: 'macro_type'`
and
`FormatTranslators.py", line 534, in ReadNetsFile
    self.insts[inst_name].AddInputPin(MacroPin(pin_name, inst_name, sink[1], sink[2]))
TypeError: __init__() missing 1 required positional argument: 'macro_type'` ,
Add type "MACRO" since the macro_type must be "MACRO".

2. Add MacroName in front of Pin Name
MacroPins were named with "`Pinput_Num`" and "`Poutput_Num`", it may be ambigous however.
The driver cell cannot figure out which pin to connect since the name  "`Pinput_Num`" is not unique.
Similar to the example in google's circuit training, the macro pins were named with "`MacroName/Pinput_Num`" to avoid ambiguity.